### PR TITLE
Fixed compilation errors. Updated deprecated func.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Optional:
 __Note__: Make sure the system is up to date ```apt-get update && apt-get dist-upgrade``` then reboot before running the following command:
 
 ```
-apt-get install libyaml-cpp-dev libpoco-dev rapidjson-dev libtsan0 libboost-all-dev libb64-dev libwireshark-data build-essential 
+apt-get install libyaml-cpp-dev libpoco-dev rapidjson-dev libtsan0 libboost-all-dev libb64-dev libwireshark-data build-essential libnl-genl-3-dev
 ```
 
 ## Load and compile

--- a/utils/stringHelper.cpp
+++ b/utils/stringHelper.cpp
@@ -24,29 +24,30 @@
 
 char * wifibeat::utils::stringHelper::hex2string(const uint8_t * data, unsigned int length, unsigned int offset, unsigned int howMany, bool useSeparator, char separator)
 {
-	if (length == 0 || length < offset + howMany ) {
-		return NULL;
-	}
+    if (length == 0 || length < offset + howMany ) {
+        return NULL;
+    }
 
-	char * ret = NULL;
-	if (useSeparator) {
-		// Separator
-		ret = (char *) calloc(1, howMany * 3);
-		for (unsigned int i = 0; i < howMany; ++i) {
-			snprintf(ret + (i *3), 2, "%02x", data[i + offset]);
-			ret[(i * 3) + 2] = separator;
-		}
-		ret[(howMany * 3) - 1] = 0;
-	} else {
-		// No separator
-		ret = (char *) calloc(1, (howMany * 2) + 1);
-		for (unsigned int i = 0; i < howMany; ++i) {
-			snprintf(ret + (i * 2), 2, "%02x", data[i + offset]);
-		}
-	}
+    char * ret = NULL;
+    if (useSeparator) {
+        // Separator
+        ret = (char *) calloc(1, howMany * 3);
+        for (unsigned int i = 0; i < howMany; ++i) {
+            snprintf(ret + (i *3), 3, "%02x", data[i + offset]);
+            ret[(i * 3) + 2] = separator;
+        }
+        ret[(howMany * 3) - 1] = 0;
+    } else {
+        // No separator
+        ret = (char *) calloc(1, (howMany * 2) + 1);
+        for (unsigned int i = 0; i < howMany; ++i) {
+            snprintf(ret + (i * 2), 3, "%02x", data[i + offset]);
+        }
+    }
 
-	return ret;
+    return ret;
 }
+
 
 string wifibeat::utils::stringHelper::mac2str(Dot11::address_type mac)
 {
@@ -91,14 +92,17 @@ void wifibeat::utils::stringHelper::to_lower(std::string & str)
 // trim from start (in place)
 void wifibeat::utils::stringHelper::ltrim(std::string &s) {
     s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-            std::not1(std::ptr_fun<int, int>(std::isspace))));
+            [](unsigned char ch){ return !std::isspace(ch); }));
 }
+
+
 
 // trim from end (in place)
 void wifibeat::utils::stringHelper::rtrim(std::string &s) {
     s.erase(std::find_if(s.rbegin(), s.rend(),
-            std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+            [](unsigned char ch){ return !std::isspace(ch); }).base(), s.end());
 }
+
 
 // trim from both ends (in place)
 void wifibeat::utils::stringHelper::trim(std::string &s) {

--- a/utils/tins.cpp
+++ b/utils/tins.cpp
@@ -975,14 +975,9 @@ bool wifibeat::utils::tins::ParseDot11ManagementOptions(const Tins::Dot11::optio
 
 					// Display suite
 					switch(item) {
-						case RSNInformation::AKMSuites::PMKSA:
+						case RSNInformation::AKMSuites::PSK:
 							jo->Add("type", 1ULL);
 							jo->Add("value", (oui * 256) + 1);
-							jo->Add("value_parsed", string("PMKSA"));
-							break;
-						case RSNInformation::AKMSuites::PSK:
-							jo->Add("type", 2ULL);
-							jo->Add("value", (oui * 256) + 2);
 							jo->Add("value_parsed", string("PSK"));
 							break;
 						default:


### PR DESCRIPTION
Please review this as I am not a C++ developer and used chatGPT to help me get this compiled and running. 

1. **Deprecation of `std::ptr_fun<int, int>` and `std::not1` in string trimming functions**

   The `std::ptr_fun` and `std::not1` functions were deprecated in C++17 and removed in C++20. These functions were used in the `wifibeat::utils::stringHelper::ltrim` and `wifibeat::utils::stringHelper::rtrim` functions. To ensure compatibility with C++17 and later, we replaced these functions with equivalent lambda expressions.

   In `wifibeat::utils::stringHelper::ltrim`:

   ```cpp
   void wifibeat::utils::stringHelper::ltrim(std::string &s) {
       s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
           return !std::isspace(ch);
       }));
   }
   ```

   In `wifibeat::utils::stringHelper::rtrim`:

   ```cpp
   void wifibeat::utils::stringHelper::rtrim(std::string &s) {
       s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
           return !std::isspace(ch);
       }).base(), s.end());
   }
   ```

2. **Truncation of `snprintf` output**

   The output of the `snprintf` function in `wifibeat::utils::stringHelper::hex2string` was getting truncated. This was because the size of the buffer passed to `snprintf` did not account for the null-terminating character. We adjusted the buffer size to prevent truncation.

   In `wifibeat::utils::stringHelper::hex2string`:

   ```cpp
   snprintf(ret + (i *3), 3, "%02x", data[i + offset]);
   ```
   and
   ```cpp
   snprintf(ret + (i * 2), 3, "%02x", data[i + offset]);
   ```

3. **'PMKSA' not recognized in `Tins::RSNInformation::AKMSuites`**

   The code contained a switch case for `RSNInformation::AKMSuites::PMKSA`, but 'PMKSA' is not a recognized member of `Tins::RSNInformation::AKMSuites`. To resolve this, we removed the `RSNInformation::AKMSuites::PMKSA` case.

   Changes in the switch statement:

   ```cpp
   switch(item) {
       case RSNInformation::AKMSuites::PSK:
           jo->Add("type", 1ULL);
           jo->Add("value", (oui * 256) + 1);
           jo->Add("value_parsed", string("PSK"));
           break;
       default:
           jo->Add("type", string("unknown"));
           break;
   }
   ```

4. **Missing `libnl-genl-3` during compilation**

   During the compilation of the project, the linker could not find the `libnl-genl-3` library. This was resolved by installing the `libnl-genl-3-dev` package on the system.

   ```sh
   sudo apt-get install libnl-genl-3-dev
   ```

These changes were necessary to resolve compilation errors and update deprecated functions. The changes ensure that the code is compatible with modern versions of C++ and that the necessary libraries are correctly linked during compilation.